### PR TITLE
Run the build to resolve failed image mirror prow job

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ make kind-delete-cluster
 - The `governance-policy-template-sync` is part of the `open-cluster-management` community. For more information, visit: [open-cluster-management.io](https://open-cluster-management.io).
 
 <!---
-Date: 8/18/2021
+Date: 1/21/2022
 -->


### PR DESCRIPTION
The release 2.4 image mirror prow job failed.  I think this could
impact anything wanting the `latest-2.4` image -- maybe automation.

The failed job is:
https://storage.googleapis.com/origin-ci-test/logs/branch-ci-stolostron-governance-policy-template-sync-release-2.4-latest-image-mirror/1482051467576610816/build-log.txt

I think this is just a random failure and a retry will work.

Signed-off-by: Gus Parvin <gparvin@redhat.com>