### PR TITLE
Requeue the request if API mapping isn't found

### DIFF
--- a/test/e2e/case2_error_test.go
+++ b/test/e2e/case2_error_test.go
@@ -64,18 +64,17 @@ var _ = Describe("Test error handling", func() {
 			"-n", testNamespace)
 		Expect(err).Should(BeNil())
 		By("Creating event with decode err on managed cluster in ns:" + testNamespace)
-		eventList := utils.ListWithTimeout(clientManagedDynamic, gvrEvent, metav1.ListOptions{FieldSelector: "involvedObject.name=default.case2-template-mapping-error"}, 2, true, defaultTimeoutSeconds)
-		By("Deleting the event to clean up")
-		for _, event := range eventList.Items {
-			_, err = utils.KubectlWithOutput("delete", "event", event.GetName(), "-n", testNamespace)
-			Expect(err).Should(BeNil())
-		}
-		eventList = utils.ListWithTimeout(clientManagedDynamic, gvrEvent, metav1.ListOptions{FieldSelector: "involvedObject.name=default.case2-template-mapping-error"}, 0, true, defaultTimeoutSeconds)
+		utils.ListWithTimeout(clientManagedDynamic, gvrEvent, metav1.ListOptions{FieldSelector: "involvedObject.name=default.case2-template-mapping-error"}, 2, true, defaultTimeoutSeconds)
 		By("Deleting ../resources/case2_error_test/template-mapping-error.yaml to clean up")
 		_, err = utils.KubectlWithOutput("delete", "-f", "../resources/case2_error_test/template-mapping-error.yaml",
 			"-n", testNamespace)
 		Expect(err).Should(BeNil())
 		utils.ListWithTimeout(clientManagedDynamic, gvrPolicy, metav1.ListOptions{}, 0, true, defaultTimeoutSeconds)
+		By("Deleting the events to clean up")
+		_, err = utils.KubectlWithOutput("delete", "event", "-n", testNamespace, "--field-selector",
+			"involvedObject.name=default.case2-template-mapping-error")
+		Expect(err).Should(BeNil())
+		utils.ListWithTimeout(clientManagedDynamic, gvrEvent, metav1.ListOptions{FieldSelector: "involvedObject.name=default.case2-template-mapping-error"}, 0, true, defaultTimeoutSeconds)
 	})
 	It("should generate duplicate policy template err event", func() {
 		By("Creating ../resources/case2_error_test/working-policy-duplicate.yaml on managed cluster in ns:" + testNamespace)

--- a/test/resources/policies.ibm.com_trustedcontainerpolicies_crd.yaml
+++ b/test/resources/policies.ibm.com_trustedcontainerpolicies_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: trustedcontainerpolicies.policies.ibm.com
@@ -10,70 +10,78 @@ spec:
     plural: trustedcontainerpolicies
     singular: trustedcontainerpolicy
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: TrustedContainerPolicy is the Schema for the trustedcontainerpolicies API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TrustedContainerPolicySpec defines the desired state of TrustedContainerPolicy
-          properties:
-            labelSelector:
-              additionalProperties:
-                type: string
-              type: object
-            imageRegistry:
-              type: string
-            maxClusterRoleBindingGroups:
-              type: integer
-            maxClusterRoleBindingUsers:
-              type: integer
-            maxRoleBindingGroupsPerNamespace:
-              type: integer
-            maxRoleBindingUsersPerNamespace:
-              type: integer
-            namespaceSelector:
-              description: Target defines the list of namespaces to include/exclude
-              properties:
-                exclude:
-                  items:
-                    type: string
-                  type: array
-                include:
-                  items:
-                    type: string
-                  type: array
-              type: object
-            remediationAction:
-              description: 'RemediationAction : enforce or inform'
-              type: string
-            severity:
-              description: 'Severity : low, medium or high'
-              type: string
-          type: object
-        status:
-          description: TrustedContainerPolicyStatus defines the observed state of TrustedContainerPolicy
-          properties:
-            compliant:
-              description: ComplianceState shows the state of enforcement
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: TrustedContainerPolicy is the Schema for the trustedcontainerpolicies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TrustedContainerPolicySpec defines the desired state of TrustedContainerPolicy
+            properties:
+              labelSelector:
+                additionalProperties:
+                  type: string
+                type: object
+              imageRegistry:
+                type: string
+              maxClusterRoleBindingGroups:
+                type: integer
+              maxClusterRoleBindingUsers:
+                type: integer
+              maxRoleBindingGroupsPerNamespace:
+                type: integer
+              maxRoleBindingUsersPerNamespace:
+                type: integer
+              namespaceSelector:
+                description: Target defines the list of namespaces to include/exclude
+                properties:
+                  exclude:
+                    items:
+                      type: string
+                    type: array
+                  include:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              remediationAction:
+                description: 'RemediationAction : enforce or inform'
+                type: string
+              severity:
+                description: 'Severity : low, medium or high'
+                type: string
+            type: object
+          status:
+            description: TrustedContainerPolicyStatus defines the observed state of TrustedContainerPolicy
+            properties:
+              compliant:
+                description: ComplianceState shows the state of enforcement
+                type: string
+            type: object
+        required:
+        - metadata
+        - spec
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
This should ensure that the template-sync keeps retrying on Policies
where the specific policy type CRD (eg ConfigurationPolicy) hasn't been
created on the cluster yet. Previously, the template sync would try a
few times, but then these policies would not get retried until the cache
was fully refreshed, or the controller restarted.

Note on requeue behavior: it is not instantly reconciled again. From an
experiment, it looks like it tries again after 5 seconds about a dozen
times, then backs off exponentially to a 16 minute, 40 second wait. That
maximum wait could be configured through the RateLimiter controller
option (currently, this uses the default).

Refs:
 - https://github.com/stolostron/backlog/issues/21640

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>