### PR TITLE
Emit template-error if template already exists

### DIFF
--- a/controllers/template_sync.go
+++ b/controllers/template_sync.go
@@ -273,14 +273,33 @@ func (r *PolicyReconciler) Reconcile(ctx context.Context, request reconcile.Requ
 			}
 		}
 
-		refName := eObject.GetOwnerReferences()[0].Name
+		refName := ""
+
+		for _, ownerref := range eObject.GetOwnerReferences() {
+			refName = ownerref.Name
+
+			break // just get the first ownerReference, if there are any at all
+		}
+
 		// violation if object reference and policy don't match
 		if instance.GetName() != refName {
-			errMsg := fmt.Sprintf(
-				"Template name must be unique. Policy template with kind: %s name: %s already exists in policy %s",
-				tObjectUnstructured.Object["kind"],
-				tName,
-				refName)
+			var errMsg string
+
+			if refName == "" {
+				errMsg = fmt.Sprintf(
+					"Template name must be unique. Policy template with "+
+						"kind: %s name: %s already exists outside of a Policy",
+					tObjectUnstructured.Object["kind"],
+					tName)
+			} else {
+				errMsg = fmt.Sprintf(
+					"Template name must be unique. Policy template with "+
+						"kind: %s name: %s already exists in policy %s",
+					tObjectUnstructured.Object["kind"],
+					tName,
+					refName)
+			}
+
 			resultError = errors.NewBadRequest(errMsg)
 
 			r.emitTemplateError(instance, tIndex, tName, errMsg)

--- a/test/resources/case2_error_test/working-policy-configpol.yaml
+++ b/test/resources/case2_error_test/working-policy-configpol.yaml
@@ -1,0 +1,17 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: case2-config-policy
+spec:
+  remediationAction: inform
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: nginx-pod-e2e
+          namespace: default
+        spec:
+          containers:
+            - name: nginx


### PR DESCRIPTION
Previously, if a Policy defined a template that already exists, it assumed that another Policy had defined it, and tried to get its owner reference in order to give a helpful error message. But if the template was created outside of a Policy, then this process would panic.

Refs:
 - https://issues.redhat.com/browse/ACM-4211
 - https://github.com/open-cluster-management-io/governance-policy-framework-addon/pull/29